### PR TITLE
Fix a typo on the front page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -115,7 +115,7 @@
                         <h2>Great ecosystem</h2>
                         <h3>Powered by .NET</h3>
                     </hgroup>
-                    <p>.NET is a mature and wildly adopted ecosystem. It provides a wide range of tools and frameworks, as well as a large and active community that provides support and resources.</p>
+                    <p>.NET is a mature and widely adopted ecosystem. It provides a wide range of tools and frameworks, as well as a large and active community that provides support and resources.</p>
                     <a href="https://dotnet.microsoft.com/learn/dotnet/what-is-dotnet">Learn more</a>
                 </div>
                 <picture class="content-image">


### PR DESCRIPTION
I've opened a issue on the main repository because I have not found this repository. https://github.com/fabulous-dev/Fabulous/issues/1099

I've closed it and now I opened a PR with the fix here. Here is the original issue text:

> I have not found the repository for the website, otherwise I'd have put the issue (or the fix) there. But on the page there is a somewhat funny typo. ".NET is a mature and wildly adopted ecosystem." should probably be more like ".NET is a mature and widely adopted ecosystem."
> 
> ![Image](https://github.com/user-attachments/assets/0caf7f78-0039-45f2-ba8a-86984733477e)
> 
> If someone knows the github for the actual website, let me know so I can create a PR there.

